### PR TITLE
HY-721: Don't Run jshint When Watching test or integration

### DIFF
--- a/src/config/watch.js
+++ b/src/config/watch.js
@@ -44,7 +44,7 @@ module.exports = function(settings) {
                     files.index, globs.src, globs.templates, globs.unitSpecs, globs.testTemplates, globs.examples,
                     globs.html, globs.css
                 ],
-                tasks: ['jshint', 'clean:test', 'jasmine:test'],
+                tasks: ['clean:test', 'jasmine:test'],
                 options: {
                     livereload: livereloadPort
                 }
@@ -54,7 +54,7 @@ module.exports = function(settings) {
                     files.index, globs.src, globs.templates, globs.integrationSpecs, globs.testTemplates,
                     globs.examples, globs.html, globs.css
                 ],
-                tasks: ['jshint', 'clean:test', 'jasmine:integration'],
+                tasks: ['clean:test', 'jasmine:integration'],
                 options: {
                     livereload: livereloadPort
                 }


### PR DESCRIPTION
When running the `test` and `integration` tasks, a watch is started.
This watch incorrectly runs `jshint` on file changes. It should not.
#### [JIRA Ticket](https://jira.webfilings.com/browse/HY-721)
## Unit Tests
- None needed
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-grunt.git
$ cd wf-grunt

# do not skip these!
$ git fetch && 
git checkout HY-721_no_lint_on_watches_for_test && 
./init.sh && 
grunt qa
```
- Should see no console errors.

@lancefisher-wf 
@patkujawa-wf 
@robbecker-wf 
@nathanevans-wf (cause we need a body :))
